### PR TITLE
Add flag to send request body as json

### DIFF
--- a/mailwizz/client.py
+++ b/mailwizz/client.py
@@ -46,6 +46,10 @@ class Client(Base):
     # the DELETE params sent in the request.
     params_delete = {}
 
+    # Whether or not to pass data to requests using json kwarg
+    # Does not apply to GET
+    send_as_json = False
+
     def __init__(self, options):
         self.__populate(options)
 
@@ -119,3 +123,6 @@ class Client(Base):
 
         if 'headers' in options:
             self.headers = options['headers']
+
+        if 'send_as_json' in options:
+            self.send_as_json = options['send_as_json']

--- a/mailwizz/client.py
+++ b/mailwizz/client.py
@@ -47,7 +47,7 @@ class Client(Base):
     params_delete = {}
 
     # Whether or not to pass data to requests using json kwarg
-    # Does not apply to GET
+    # Only applies (currently) to PUT
     send_as_json = False
 
     def __init__(self, options):

--- a/mailwizz/endpoint/list_subscribers.py
+++ b/mailwizz/endpoint/list_subscribers.py
@@ -81,12 +81,14 @@ class ListSubscribers(Base):
 
         return client.request()
 
-    def update(self, list_uid: str, subscriber_uid: str, data: dict):
+    def update(self, list_uid: str, subscriber_uid: str,
+               data: dict, send_as_json: bool = False):
         """
         Update existing subscriber in given list
         :param list_uid:
         :param subscriber_uid:
         :param data:
+        :param send_as_json: whether or not to send body as json
         :return:
         """
 
@@ -98,7 +100,8 @@ class ListSubscribers(Base):
                     subscriber_uid=subscriber_uid
                 )
             ),
-            'params_put': data
+            'params_put': data,
+            'send_as_json': send_as_json
         })
 
         return client.request()

--- a/mailwizz/endpoint/list_subscribers.py
+++ b/mailwizz/endpoint/list_subscribers.py
@@ -48,18 +48,21 @@ class ListSubscribers(Base):
 
         return client.request()
 
-    def create(self, list_uid: str, data: dict):
+    def create(self, list_uid: str, data: dict,
+               send_as_json: bool = False):
         """
         Create a new subscriber in the given list
         :param list_uid:
         :param data:
+        :param send_as_json: whether or not to send body as json
         :return:
         """
 
         client = Client({
             'method': Client.METHOD_POST,
             'url': self.config.get_api_url('lists/{list_uid}/subscribers'.format(list_uid=list_uid)),
-            'params_post': data
+            'params_post': data,
+            'send_as_json': True
         })
 
         return client.request()

--- a/mailwizz/endpoint/list_subscribers.py
+++ b/mailwizz/endpoint/list_subscribers.py
@@ -62,7 +62,7 @@ class ListSubscribers(Base):
             'method': Client.METHOD_POST,
             'url': self.config.get_api_url('lists/{list_uid}/subscribers'.format(list_uid=list_uid)),
             'params_post': data,
-            'send_as_json': True
+            'send_as_json': send_as_json
         })
 
         return client.request()

--- a/mailwizz/endpoint/list_subscribers.py
+++ b/mailwizz/endpoint/list_subscribers.py
@@ -48,13 +48,11 @@ class ListSubscribers(Base):
 
         return client.request()
 
-    def create(self, list_uid: str, data: dict,
-               send_as_json: bool = False):
+    def create(self, list_uid: str, data: dict):
         """
         Create a new subscriber in the given list
         :param list_uid:
         :param data:
-        :param send_as_json: whether or not to send body as json
         :return:
         """
 
@@ -62,7 +60,6 @@ class ListSubscribers(Base):
             'method': Client.METHOD_POST,
             'url': self.config.get_api_url('lists/{list_uid}/subscribers'.format(list_uid=list_uid)),
             'params_post': data,
-            'send_as_json': send_as_json
         })
 
         return client.request()

--- a/mailwizz/request.py
+++ b/mailwizz/request.py
@@ -56,38 +56,36 @@ class Request(Base):
         """
 
         client = self.client
+        kwargs = {
+            'url': client.url,
+            'headers': client.headers,
+            'timeout': client.timeout
+        }
 
         if client.is_get_method():
-            return requests.get(
-                url=client.url,
-                params=client.params_get,
-                headers=client.headers,
-                timeout=client.timeout
-            )
+            kwargs['params'] = client.params_get
+            return requests.get(**kwargs)
 
         if client.is_post_method():
-            return requests.post(
-                url=client.url,
-                data=client.params_post,
-                headers=client.headers,
-                timeout=client.timeout
-            )
+            if client.send_as_json:
+                kwargs['json'] = client.params_post
+            else:
+                kwargs['data'] = client.params_post
+            return requests.post(**kwargs)
 
         if client.is_put_method():
-            return requests.put(
-                url=client.url,
-                data=client.params_put,
-                headers=client.headers,
-                timeout=client.timeout
-            )
+            if client.send_as_json:
+                kwargs['json'] = client.params_put
+            else:
+                kwargs['data'] = client.params_put
+            return requests.put(**kwargs)
 
         if client.is_delete_method():
-            return requests.delete(
-                url=client.url,
-                data=client.params_put,
-                headers=client.headers,
-                timeout=client.timeout
-            )
+            if client.send_as_json:
+                kwargs['json'] = client.params_put
+            else:
+                kwargs['data'] = client.params_put
+            return requests.delete(**kwargs)
 
     def _sign(self, request_url):
         """

--- a/mailwizz/request.py
+++ b/mailwizz/request.py
@@ -67,10 +67,7 @@ class Request(Base):
             return requests.get(**kwargs)
 
         if client.is_post_method():
-            if client.send_as_json:
-                kwargs['json'] = client.params_post
-            else:
-                kwargs['data'] = client.params_post
+            kwargs['data'] = client.params_post
             return requests.post(**kwargs)
 
         if client.is_put_method():
@@ -81,10 +78,7 @@ class Request(Base):
             return requests.put(**kwargs)
 
         if client.is_delete_method():
-            if client.send_as_json:
-                kwargs['json'] = client.params_put
-            else:
-                kwargs['data'] = client.params_put
+            kwargs['data'] = client.params_put
             return requests.delete(**kwargs)
 
     def _sign(self, request_url):


### PR DESCRIPTION
Sending the nested dictionary described at https://forum.mailwizz.com/threads/re-subscribe-a-user-thats-previously-unsubscribed-via-the-api.641/post-3541 via the `data` argument in requests does not lead to expected serialization, and thus the `status` attribute is never updated.  Sending via the `json` argument will lead to requests serializing to the expected format, allowing the attribute to be updated.  